### PR TITLE
Refactor: Use iota for event constants

### DIFF
--- a/graph/globals.go
+++ b/graph/globals.go
@@ -228,78 +228,81 @@ EventNodeCreated is thrown when a node was created.
 
 Parameters: partition of created node, created node
 */
-const EventNodeCreated = 0x01
+// Graph events define the set of actions that can trigger the rules engine.
+// The sequence is generated using iota, starting from 1
+const (
+      EventNodeCreated = iota + 1
 
 /*
 EventNodeUpdated is thrown when a node was updated.
 
 Parameters: partition of updated node, updated node, old node
 */
-const EventNodeUpdated = 0x02
+     EventNodeUpdated 
 
 /*
 EventNodeDeleted is thrown when a node was deleted.
 
 Parameters: partition of deleted node, deleted node
 */
-const EventNodeDeleted = 0x03
+     EventNodeDeleted
 
 /*
 EventEdgeCreated is thrown when an edge was created.
 
 Parameters: partition of created edge, created edge
 */
-const EventEdgeCreated = 0x04
+     EventEdgeCreated 
 
 /*
 EventEdgeUpdated is thrown when an edge was updated.
 
 Parameters: partition of updated edge, updated edge, old edge
 */
-const EventEdgeUpdated = 0x05
+    EventEdgeUpdated 
 
 /*
 EventEdgeDeleted is thrown when an edge was deleted.
 
 Parameters: partition of deleted edge, deleted edge
 */
-const EventEdgeDeleted = 0x06
+    EventEdgeDeleted
 
 /*
 EventNodeStore is thrown before a node is stored (always overwriting existing values).
 
 Parameters: partition of node to store, node to store
 */
-const EventNodeStore = 0x07
+    EventNodeStore 
 
 /*
 EventNodeUpdate is thrown before a node is updated.
 
 Parameters: partition of node to update, node to update
 */
-const EventNodeUpdate = 0x08
+   EventNodeUpdate
 
 /*
 EventNodeDelete is thrown before a node is deleted.
 
 Parameters: partition of node to delete, key of node to delete, kind of node to delete
 */
-const EventNodeDelete = 0x09
+   EventNodeDelete 
 
 /*
 EventEdgeStore is thrown before an edge is stored (always overwriting existing values).
 
 Parameters: partition of stored edge, stored edge
 */
-const EventEdgeStore = 0x0A
+   EventEdgeStore
 
 /*
 EventEdgeDelete is thrown before an edge is deleted.
 
 Parameters: partition of deleted edge, key of edge to delete, kind of edge to delete
 */
-const EventEdgeDelete = 0x0B
-
+  EventEdgeDelete 
+ )
 /*
 ErrEventHandled is a special error which an event handler can return to
 notify the GraphManager that no further action is necessary. No error will


### PR DESCRIPTION
Replaced manual numbering of event constants with a single const() block using iota for better maintainability and adherence to Go idioms.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Standardized event identifiers under a unified enumeration for improved consistency and maintainability.
  - Public event names remain the same; underlying numeric codes have been normalized to a sequential scheme.

- Notes
  - No changes to user-facing features or behavior.
  - If you rely on raw event codes in custom integrations or logs, verify compatibility to ensure mappings remain correct.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->